### PR TITLE
Fix Flaky Test

### DIFF
--- a/tests/autoyaml_test.py
+++ b/tests/autoyaml_test.py
@@ -45,6 +45,7 @@ class TestAutoyamlMethods(unittest.TestCase):
            self.assertNotIn(self.enc_app, filename.read())
 
     def test_b_decrypt_config(self):
+        write_config(self.enc_config, self.enc_app, encrypted=True, password_function=self.password_function)
         loaded_config = load_config(self.enc_app, password_function=self.password_function) 
         self.assertEqual(loaded_config, self.enc_config)
         loaded_config["extra_field"] = random_string()


### PR DESCRIPTION
<h2>What is the purpose of this PR</h2>

- This PR patches `tests/autoyaml_test.py::TestAutoyamlMethods::test_b_decrypt_config` and prevents it from failing when it is run by itself
- Test is flaky (non-deterministic) and depends on `tests/autoyaml_test.py::TestAutoyamlMethods::test_a_encrypt_config` to set up a state to pass, but the test fails when it is run by itself otherwise

---

<h2>Expected Result</h2> 

- Test `tests/autoyaml_test.py::TestAutoyamlMethods::test_b_decrypt_config` should pass when run both by itself and after `tests/autoyaml_test.py::TestAutoyamlMethods::test_a_encrypt_config`

---
<h2>Actual Result</h2> 

- Test `tests/autoyaml_test.py::TestAutoyamlMethods::test_b_decrypt_config`  fails when it is run by itself
- Specifically, we get the following
```
____________________________________________________________________________________ TestAutoyamlMethods.test_b_decrypt_config ____________________________________________________________________________________

self = <tests.autoyaml_test.TestAutoyamlMethods testMethod=test_b_decrypt_config>

    def test_b_decrypt_config(self):
        loaded_config = load_config(self.enc_app, password_function=self.password_function)
>       self.assertEqual(loaded_config, self.enc_config)
E       AssertionError: {} != {'appname': 'umgkzsgiab'}
E       - {}
E       + {'appname': 'umgkzsgiab'}

tests/autoyaml_test.py:49: AssertionError
```

---

<h2>Reproduce the test failure</h2>

- Run `python3 -m pytest tests/autoyaml_test.py::TestAutoyamlMethods::test_b_decrypt_config` 

---
<h2>Why the Test Fails</h2> 

- The test fails because the test is dependent on some state that is not set when it is run by itself. 

---
<h2>Fix</h2>

- The changes in this pull request sets the state and makes the test pass when it is run by itself. 

---